### PR TITLE
Updates OAuth to V2

### DIFF
--- a/adsk-auth.js
+++ b/adsk-auth.js
@@ -41,19 +41,19 @@ export class AdskAuth extends events.EventEmitter {
 		if (this.timeoutId)
 			clearTimeout(this.timeoutId);
 
-		let dataString = "client_id=" + this.key
-			+ "&client_secret=" + this.secret
-			+ "&grant_type=client_credentials"
+		let dataString = "grant_type=client_credentials" 
 			+ "&scope=" + scope;
 
 		let headers = {
-			"Content-Type": "application/x-www-form-urlencoded"
+			"Content-Type": "application/x-www-form-urlencoded",
+			"Accept": "application/json",
+			"Authorization": `Basic ${btoa(`${this.key}:${this.secret}`)}`,
 		};
 
 		let options = {
 			host: this.endpoint,
 			port: 443,
-			path: "/authentication/v1/authenticate",
+			path: "/authentication/v2/token",
 			method: "POST",
 			headers: headers,
 		};


### PR DESCRIPTION
As V1 was sunsetted, it converts the API V1 (v1/authenticate) to (v2/token) following the [instructions given by APS](https://aps.autodesk.com/en/docs/oauth/v2/tutorials/get-2-legged-token/) and the authentication code from Tandem (App Server / Service Tests).